### PR TITLE
Add an alpine build

### DIFF
--- a/0.6.2/alpine/Dockerfile
+++ b/0.6.2/alpine/Dockerfile
@@ -1,0 +1,100 @@
+# Build stage for BerkeleyDB
+FROM alpine as berkeleydb
+
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add build-base
+RUN apk --no-cache add openssl
+
+ENV BERKELEYDB_VERSION=db-4.8.30.NC
+ENV BERKELEYDB_PREFIX=/opt/berkleydb
+
+RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
+RUN tar -xzf *.tar.gz
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
+RUN mkdir -p ${BERKELEYDB_PREFIX}
+
+WORKDIR /${BERKELEYDB_VERSION}/build_unix
+
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
+RUN make -j4
+RUN make install
+RUN rm -rf ${BERKELEYDB_PREFIX}/docs
+
+# Build stage for Peercoind
+FROM alpine as peercoin-build
+
+COPY --from=berkeleydb /opt /opt
+
+RUN apk --no-cache add autoconf \
+    automake \
+    boost-dev \
+    build-base \
+    ## chrpath \        Was in bticoin one, doesn't appear to be needed
+    ## file \           Was in bticoin one, doesn't appear to be needed
+    ## libevent-dev \   Was in bticoin one, doesn't appear to be needed
+    openssl \
+    openssl-dev \
+    libtool \
+    # libexecinfo-dev \ Needed for execinfo/backtrace in src/util.cpp but still doesn't work
+    linux-headers 
+
+ENV PEERCOIN_VERSION=0.6.2 \
+    PEERCOIN_SHA=d64a8fdcd874d2e211f5dd3002e187769b3ec656f985f538ea0510f1b58ac2b6 \
+    PEERCOIN_PREFIX=/opt/peercoin
+
+RUN wget -q -O peercoin.tar.gz https://github.com/peercoin/peercoin/archive/v${PEERCOIN_VERSION}ppc.tar.gz \
+    && echo "${PEERCOIN_SHA}  peercoin.tar.gz" | sha256sum -c - 
+
+RUN tar -xzf peercoin.tar.gz
+
+WORKDIR /peercoin-${PEERCOIN_VERSION}ppc
+
+RUN sed -i '/AC_PREREQ/a\ARFLAGS=cr' configure.ac \
+    && sed -i s:sys/fcntl.h:fcntl.h: src/compat.h \
+# ./configure can't find berkley db unless we do this
+RUN ln -s /opt/berkleydb /usr/include/db4.8 \
+    && ln -s /opt/berkleydb/include/* /usr/include  \
+    && ln -s /opt/berkleydb/lib/* /usr/lib
+
+# Alpine doesn't contain backtrace so we nuke references to it, even including libexecinfo-dev
+RUN sed -i 's/.*backtrace.*//g' src/util.cpp \
+    && sed -i 's/.*execinfo.h.*//g' src/util.cpp
+
+RUN ./autogen.sh
+RUN ./configure \
+    --prefix=${PEERCOIN_PREFIX} \
+    --mandir=/usr/share/man \
+    --disable-tests \
+    --disable-ccache \
+    --with-gui=no
+
+RUN make
+RUN make install
+RUN strip ${PEERCOIN_PREFIX}/bin/peercoin-cli
+RUN strip ${PEERCOIN_PREFIX}/bin/peercoind
+
+# Build stage for compiled artifacts
+FROM alpine
+
+RUN adduser -S peercoin
+RUN apk --no-cache add \
+  boost \
+  boost-program_options \
+  openssl \
+  su-exec
+
+ENV PEERCOIN_DATA=/home/peercoin/.peercoin
+ENV PEERCOIN_PREFIX=/opt/peercoin
+ENV PATH=${PEERCOIN_PREFIX}/bin:$PATH
+
+COPY --from=peercoin-build /opt /opt
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/peercoin/.peercoin"]
+
+EXPOSE 9901 9902 9903 9904
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["peercoind"]

--- a/0.6.2/alpine/docker-entrypoint.sh
+++ b/0.6.2/alpine/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for peercoind"
+
+  set -- peercoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "peercoind" ]; then
+  mkdir -p "$PEERCOIN_DATA"
+  chmod 700 "$PEERCOIN_DATA"
+  chown -R peercoin "$PEERCOIN_DATA"
+
+  echo "$0: setting data directory to $PEERCOIN_DATA"
+
+  set -- "$@" -datadir="$PEERCOIN_DATA"
+fi
+
+if [ "$1" = "peercoind" ] || [ "$1" = "peercoin-cli" ]; then
+  echo
+  exec su-exec peercoin "$@"
+fi
+
+echo
+exec "$@"


### PR DESCRIPTION
Taking heavy inspiration from the [bitcoin-core alpine build](https://github.com/ruimarinho/docker-bitcoin-core).  Makes use of docker multi-stage builds so we don't end up with any cruft in the final image, just the compiled berkleydb + peercoind in the /opt folder.

It's probably not ready for primetime yet, most notably the workarounds for execinfo, but wanted to get it looked at.

Also I think it's worth moving to the versioned folder structure, again inspired by the bitcoin-core docker image.

This resulting image is 54MB vs the 580MB for the debian version of docker-peercoind.