### PR TITLE
Dockerfile: quote data volume name

### DIFF
--- a/0.9.0/Dockerfile
+++ b/0.9.0/Dockerfile
@@ -97,7 +97,7 @@ ENV RPC_USER=ppcuser
 COPY --from=peercoin-build /opt /opt
 COPY docker-entrypoint.sh /entrypoint.sh
 
-VOLUME [${PPC_DATA}]
+VOLUME ["${PPC_DATA}"]
 
 EXPOSE 9901 9902 9903 9904
 


### PR DESCRIPTION
so it is created properly on the filesystem. The value passed to `VOLUME` [is parsed as a string or JSON array](https://docs.docker.com/engine/reference/builder/#volume).

Fix: #10

See also: https://docs.docker.com/engine/reference/builder/#volume